### PR TITLE
Fix MouseLightJsonWriter for hortacloud-created SWCs

### DIFF
--- a/src/aind_morphology_utils/writers.py
+++ b/src/aind_morphology_utils/writers.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from pathlib import Path
+from os import PathLike
 from typing import Any, List, Optional, Union
 
 from allensdk.core import swc
@@ -39,7 +39,7 @@ class MouseLightJsonWriter:
 
     def write(
         self,
-        output_path: Union[str, Path],
+        output_path: Union[str, PathLike],
         indent: int = 4
     ) -> None:
         """


### PR DESCRIPTION
Only pre-pend the root node if filtering compartments by type, otherwise the root is duplicated.